### PR TITLE
clang-compatible

### DIFF
--- a/chemlab/utils/cdist.pxd
+++ b/chemlab/utils/cdist.pxd
@@ -2,4 +2,4 @@ cdef extern from "math.h":
     double sqrt(double) nogil
     double rint(double) nogil
 
-cdef inline double minimum_image_distance(double[:] a,double[:] b, double[:] periodic) nogil
+cdef double minimum_image_distance(double[:] a,double[:] b, double[:] periodic) nogil


### PR DESCRIPTION
There's no need for the inline declaration.

see:
https://groups.google.com/d/msg/cython-users/JCItzE6YH-o/o-5oQ3QyR_kJ
