### PR TITLE
fixed center of mass formula

### DIFF
--- a/chemlab/core/molecule.py
+++ b/chemlab/core/molecule.py
@@ -1,6 +1,5 @@
 import numpy as np
 from collections import Counter
-import numpy as np
 from copy import copy
 
 from ..libs.ckdtree import cKDTree
@@ -364,7 +363,7 @@ class Molecule(object):
     
     @property
     def center_of_mass(self):
-        return ((self.m_array * self.r_array)/self.m_array.sum()).sum(axis=0)
+        return ((self.m_array * self.r_array.T).sum(axis=1))/self.m_array.sum()
 
     @property
     def geometric_center(self):


### PR DESCRIPTION
Old code returned with this error when attempting to calculate the center of mass for a molecule:

```
>>> benzene.center_of_mass
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "chemlab/core/molecule.py", line 367, in center_of_mass
    return ((self.m_array * self.r_array)/self.m_array.sum()).sum(axis=0)
ValueError: operands could not be broadcast together with shapes (12,) (12,3) 
```
